### PR TITLE
Use different `coveralls` lib

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,8 +1,8 @@
 -r base.txt
 
+coveralls==0.4.2
 flake8==2.1.0
 nose==1.3.2
 nose-cov==1.6
 pinocchio==0.4.1
-python-coveralls==2.4.2
 tox==1.7.1


### PR DESCRIPTION
`python-coveralls` didn't submit information on the existing files for me.
Cf https://github.com/z4r/python-coveralls/issues/21.
