### PR TITLE
Use `.png` hosted on coveralls.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/0x64746b/ctx_parser.svg?branch=master)](https://travis-ci.org/0x64746b/ctx_parser)
-[![Coverage Status](https://img.shields.io/coveralls/0x64746b/ctx_parser.svg)](https://coveralls.io/r/0x64746b/ctx_parser)
+[![Coverage Status](https://coveralls.io/repos/0x64746b/ctx_parser/badge.png?branch=master)](https://coveralls.io/r/0x64746b/ctx_parser?branch=master)
 
 About
 =====


### PR DESCRIPTION
The `.svg` hosted on img.shields.io shows as a broken image on github.com and as
`vendor|unresponsive` on markable.in.

Pin branch while exchanging badge.
